### PR TITLE
[9.x] Fixed ```Illuminate\Support\Facades\Http``` phpdoc

### DIFF
--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -12,7 +12,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest asJson()
  * @method static \Illuminate\Http\Client\PendingRequest asMultipart()
  * @method static \Illuminate\Http\Client\PendingRequest async()
- * @method static \Illuminate\Http\Client\PendingRequest attach(string|array $name, string $contents = '', string|null $filename = null, array $headers = [])
+ * @method static \Illuminate\Http\Client\PendingRequest attach(string|array $name, string|resource $contents = '', string|null $filename = null, array $headers = [])
  * @method static \Illuminate\Http\Client\PendingRequest baseUrl(string $url)
  * @method static \Illuminate\Http\Client\PendingRequest beforeSending(callable $callback)
  * @method static \Illuminate\Http\Client\PendingRequest bodyFormat(string $format)


### PR DESCRIPTION
Add  missing ```resource``` type for ```attach``` method on ```$contents``` parameter  in the phpdoc.
